### PR TITLE
Set to match on directories starting with a period

### DIFF
--- a/bin/fixme.js
+++ b/bin/fixme.js
@@ -72,7 +72,7 @@ function fileFilterer (fileInformation) {
 
   ignoredDirectories.forEach(function (directoryPattern) {
     if (shouldIgnoreDirectory) return;
-    shouldIgnoreDirectory = minimatch(fileInformation.path, directoryPattern);
+    shouldIgnoreDirectory = minimatch(fileInformation.path, directoryPattern, { dot: true });
   });
 
   if (!shouldIgnoreDirectory) {


### PR DESCRIPTION
By default, `node_modules/**` will not match
`node_modules/foo/.idea/bar`, unless dot is set (see
https://github.com/isaacs/minimatch#dot).