### PR TITLE
update packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
   ],
 
   "dependencies": {
-    "byline":       "4.2.0",
-    "chalk":        "0.5.1",
-    "event-stream": "3.1.7",
-    "isbinaryfile": "2.0.2",
-    "minimatch":    "1.0.0",
+    "byline": "5.0.0",
+    "chalk": "1.1.3",
+    "event-stream": "3.3.4",
+    "isbinaryfile": "3.0.1",
+    "minimatch":    "3.0.3",
     "minimist":     "1.2.0",
-    "readdirp":     "1.1.0"
+    "readdirp": "2.1.0"
   },
 
   "devDependencies": {


### PR DESCRIPTION
I used the npm-check-updates npm module with `npm -u` to update all deps. It turns out the the minimust 1.0.0 that was being used has a known security vulnerability related to a regex denial of service. Since this is a dev dependency for me, it's not a huge deal, but figured it was worth updating everything. The only test I know to run is:

```
npm link
fixme -p test
```

this returned the requisite 7 items without any errors. Not sure if any other testing is required.