### PR TITLE
Added ability to skip checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You should then see some nice output when this is run:
   * **line_length_limit:** The number of max characters a line can be before Fixme gives up and doen not scan it for matches. If a line is too long, the regular expression will take an extremely long time to finish. *You have been warned!*
   * **skip:** List of check names to skip. Valid options: `note`, `optimize`, `todo`, `hack`, `xxx`, `fixme`, `bug`, `line`. `line` will disable the line length warning.
 
-## CLI Usage ###
+### CLI Usage ###
 
 ```sh
 fixme --help

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ fixme({
   ignored_directories:  ['node_modules/**', '.git/**', '.hg/**'],
   file_patterns:        ['**/*.js', 'Makefile', '**/*.sh'],
   file_encoding:        'utf8',
-  line_length_limit:    1000
+  line_length_limit:    1000,
+  skip:                 []
 });
 ```
 
@@ -61,8 +62,9 @@ You should then see some nice output when this is run:
   * **file_patterns:** Glob patterns for files to scan. Also uses [minimatch](https://www.npmjs.org/package/minimatch).
   * **file_encoding:** The encoding the files scanned will be opened as.
   * **line_length_limit:** The number of max characters a line can be before Fixme gives up and doen not scan it for matches. If a line is too long, the regular expression will take an extremely long time to finish. *You have been warned!*
+  * **skip:** List of check names to skip. Valid options: `note`, `optimize`, `todo`, `hack`, `xxx`, `fixme`, `bug`, `line`. `line` will disable the line length warning.
 
-### CLI Usage ###
+## CLI Usage ###
 
 ```sh
 fixme --help

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -18,6 +18,7 @@ Options:\n\
   -i, --ignored_directories  glob patterns for directories to ignore (default: node_modules/**, .git/**, .hg/**)\n\
   -e, --file_encoding        file encoding to be scanned (default: utf8)\n\
   -l, --line_length_limit    number of max characters a line (default: 1000)\n\
+  -s, --skip                 list of checks to skip (default: none)\n\
 \n\
 Examples:\n\
 \n\
@@ -71,6 +72,14 @@ if (file_encoding) {
 var line_length_limit = argv.line_length_limit || argv.l;
 if (line_length_limit) {
   options.line_length_limit = line_length_limit;
+}
+
+var skip = argv.skip || argv.s;
+if (typeof skip === 'string') {
+  skip = [skip];
+}
+if (skip) {
+  options.skip = skip;
 }
 
 fixme(options);

--- a/bin/fixme.js
+++ b/bin/fixme.js
@@ -13,6 +13,7 @@ var ignoredDirectories  = ['node_modules/**', '.git/**', '.hg/**'],
     scanPath            = process.cwd(),
     fileEncoding        = 'utf8',
     lineLengthLimit     = 1000,
+    skipChecks          = [],
     messageChecks       = {
       note: {
         regex:    /[\/\/][\/\*]\s*NOTE\s*(?:\(([^:]*)\))*\s*:?\s*(.*)/i,
@@ -259,6 +260,11 @@ function scanAndProcessMessages () {
     fileFilter: fileFilterer
   });
 
+  // Remove skipped checks for our mapping
+  skipChecks.forEach(function (checkName) {
+    delete messageChecks[checkName];
+  });
+
   // TODO: Actually do something meaningful/useful with these handlers.
   stream
     .on('warn', console.warn)
@@ -284,7 +290,7 @@ function scanAndProcessMessages () {
             messages.forEach(function (message) {
               fileMessages.messages.push(message);
             });
-          } else {
+          } else if (skipChecks.indexOf('line') === -1){
             lengthError = 'Fixme is skipping this line because its length is ' +
                           'greater than the maximum line-length of ' +
                           lineLengthLimit + '.';
@@ -321,6 +327,7 @@ function scanAndProcessMessages () {
  * @property  {Array}   options.file_patterns       An array of minimatch glob patterns for files to scan for messages.
  * @property  {String}  options.file_encoding       The encoding the files scanned will be opened with, defaults to 'utf8'.
  * @property  {Number}  options.line_length_limit   The number of characters a line can be before it is ignored. Defaults to 1000.
+ * @property  {Array}   options.skip                An array of names of checks to skip.
  */
  // TODO(johnp): Allow custom messageChecks to be added via options.
 function parseUserOptionsAndScan (options) {
@@ -347,6 +354,12 @@ function parseUserOptionsAndScan (options) {
 
     if (options.line_length_limit) {
       lineLengthLimit = options.line_length_limit;
+    }
+
+    if (options.skip &&
+        Array.isArray(options.skip) &&
+        options.skip.length) {
+      skipChecks = options.skip;
     }
   }
 


### PR DESCRIPTION
Added a new option `skip` that takes an array of check names (`note`, `optimize`, `todo`, `hack`, `xxx`, `fixme`, `bug`, `line`. `line`) to skip reporting on. `line` disables the 'SKIPPING CHECK ' warning message. The line skip is what I wanted, but I thought I'd sprinkle in a bit of usefulness with a more generic option. 

I updated the `cli.js` and the `readme`. I suggest checking out [commander](https://www.npmjs.com/package/commander) if you want to give you `cli.js` some love.

Enjoy!