### PR TITLE
Use full path when filtering files

### DIFF
--- a/bin/fixme.js
+++ b/bin/fixme.js
@@ -80,7 +80,7 @@ function fileFilterer (fileInformation) {
     filesToScan.forEach(function (filePattern) {
       if (!shouldIgnoreFile) return;
 
-      shouldIgnoreFile = !(minimatch(fileInformation.name, filePattern));
+      shouldIgnoreFile = !(minimatch(fileInformation.path, filePattern));
     });
   }
 


### PR DESCRIPTION
To enable file patterns that don't start with `**` we have to use the full path of the file for minimatching.

fixes #20